### PR TITLE
Revise TCP connection setup, align Makefile, enable Apple CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,8 +24,7 @@ jobs:
 
     - name: Set up dependencies (macOS)
       if: matrix.os == 'macos-latest'
-      run: |
-        brew install asio ffmpeg
+      run: brew install asio ffmpeg
 
     - name: Create secrets.h
       run: cp secrets.example.h secrets.h

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install asio ffmpeg curl
+        brew install asio ffmpeg
 
     - name: Create secrets.h
       run: cp secrets.example.h secrets.h

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Set up dependencies (macOS)
       if: matrix.os == 'macos-latest'
       run: |
-        brew install asio ffmpeg curl ncurses
+        brew install asio ffmpeg curl
 
     - name: Create secrets.h
       run: cp secrets.example.h secrets.h

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL:=/bin/bash
 
 CC=clang++
-CFLAGS=-std=c++2a -g3 -O3 -Ieffects -I/opt/homebrew/include
+CFLAGS=-std=c++20 -g3 -O3 -Ieffects -I/opt/homebrew/include
 LDFLAGS=
 LIBS=-lpthread -lz -lavformat -lavcodec -lavutil -lswscale -lswresample
 
@@ -19,7 +19,6 @@ Makefile for ndscpp
 Usage:
 	help	Show this help text
 	all	Build the ndscpp application
-	force	Force a rebuild of all files
 	clean	Remove all build artifacts
 
 Examples:
@@ -37,28 +36,26 @@ else
     LDFLAGS += -L/usr/lib/
 endif
 
-.PHONY: help
+all: $(EXECUTABLE)
+
 help:; @ $(info $(helptext)) :
 
-.PHONY: all
-.PHONY: phony
-.PHONY: force
-.PHONY: clean
-
-all: $(EXECUTABLE)
-force: all
-
 $(EXECUTABLE): $(OBJECTS)
-	$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
+	@echo Linking $@...
+	@$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 %.o: %.cpp $(DEPDIR)/%.d | $(DEPDIR)
-	$(CC) $(CFLAGS) $(DEPFLAGS) $(DEFINES) -c $< -o $@
+	@echo Compiling $<...
+	@$(CC) $(CFLAGS) $(DEPFLAGS) $(DEFINES) -c $< -o $@
 
 $(DEPDIR): ; @mkdir -p $@
 
 $(DEPFILES):
 
 clean:
-	rm -f $(OBJECTS) $(EXECUTABLE) $(DEPFILES)
+	@echo Cleaning build files...
+	@rm -f $(OBJECTS) $(EXECUTABLE) $(DEPFILES)
+
+.PHONY: all clean help
 
 include $(wildcard $(DEPFILES))

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,8 @@ $(EXECUTABLE): $(OBJECTS)
 	@$(CC) $(LDFLAGS) $^ -o $@ $(LIBS)
 
 %.o: %.cpp $(DEPDIR)/%.d | $(DEPDIR)
-	$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
+	@echo Compiling $<...
+	@$(CC) $(CFLAGS) $(DEPFLAGS) -c $< -o $@
 
 $(DEPDIR): ; @mkdir -p $@
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,6 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Darwin)
     CFLAGS += -I$(shell brew --prefix)/include/
     LDFLAGS += -L$(shell brew --prefix)/lib/
-else
-    CFLAGS += -I/usr/include/
-    LDFLAGS += -L/usr/lib/
 endif
 
 all: $(EXECUTABLE)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ This project uses clang++ and make, and is dependent on the libraries for asio (
 On the Mac, you'll have to install asio and ffmpeg using Homebrew; the other required libraries are usually already installed:
 
 ```shell
-brew install asio
-brew install ffmpeg
+brew install asio ffmpeg
 ```
 
 On Ubuntu, dev versions for all libraries except ncurses and pthreads have to be installed (ncurses already gets pulled in by llvm/clang):

--- a/monitor/Makefile
+++ b/monitor/Makefile
@@ -21,9 +21,6 @@ UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S), Darwin)
     INCLUDES += -I$(shell brew --prefix)/include/
     LDFLAGS += -L$(shell brew --prefix)/lib/
-else
-    INCLUDES += -I/usr/include/
-    LDFLAGS += -L/usr/lib/
 endif
 
 # Default target

--- a/socketchannel.h
+++ b/socketchannel.h
@@ -102,7 +102,6 @@ public:
 // attempt to reconnect if the connection is lost.
 
 struct ClientResponse;
-
 class SocketChannel : public ISocketChannel
 {
 public:
@@ -426,29 +425,31 @@ private:
         int keepidle = 1;         // Time in seconds before sending keepalive probes
         int keepintvl = 1;        // Time in seconds between keepalive probes
 
+        // On macOS, TCP_KEEPIDLE is called TCP_KEEPALIVE
+        #ifdef __APPLE__
+            #define TCP_KEEPIDLE TCP_KEEPALIVE
+        #endif
+
         if (setsockopt(socketFd, SOL_SOCKET, SO_KEEPALIVE, &keepalive, sizeof(keepalive)) < 0 ||
             setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0 ||
-            #ifdef __APPLE__
-                setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPALIVE, &keepidle, sizeof(keepidle)) < 0 ||
-            #else
-                setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0 ||
-            #endif
+            setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0 ||
             setsockopt(socketFd, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0)
         {
             cerr << "Could not set keepalive options for " << _friendlyName << endl;
             return false;
         }           
 
-        return true;
-    }
-
-    bool SetSocketSendTimeout(int socketFd, milliseconds timeout)
-    {
         struct timeval timeouttv;
-        timeouttv.tv_sec = timeout.count() / 1000;
-        timeouttv.tv_usec = (timeout.count() % 1000) * 1000;
+        timeouttv.tv_sec = kSendTimeout.count() / 1000;
+        timeouttv.tv_usec = (kSendTimeout.count() % 1000) * 1000;
 
-        return setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, &timeouttv, sizeof(timeouttv)) == 0;
+        if (setsockopt(socketFd, SOL_SOCKET, SO_SNDTIMEO, &timeouttv, sizeof(timeouttv)) < 0)
+        {
+            cerr << "Could not set TCP send timeout for " << _friendlyName << endl;
+            return false;
+        }
+
+        return true;
     }
 
     optional<ClientResponse> SendFrame(const vector<uint8_t>&& frame)
@@ -527,10 +528,10 @@ private:
             return false;
         }
 
-        // Set socket to non-blocking mode
+        // Set socket options (non-blocking, keepalive, send timeout)
         if (!SetSocketOptions(tempSocket))
         {
-            cerr << "Could not set socket to non-blocking mode for " << _friendlyName << endl;
+            cerr << "Could not set socket options for " << _friendlyName << endl;
             close(tempSocket);
             return false;
         }
@@ -568,12 +569,6 @@ private:
             }
         }
 
-        if (!SetSocketSendTimeout(tempSocket, kSendTimeout))
-        {
-            close(tempSocket);
-            return false;
-        }
-
         _reconnectCount++;
         cout << "Connection number " << _reconnectCount << " to " << _hostName << ":" << _port << " [" << _friendlyName << "] on thread " << this_thread::get_id() << endl; 
         _socketFd = tempSocket;
@@ -582,18 +577,15 @@ private:
 
     void EmptyQueue()
     {
-        lock_guard<mutex> lock(_mutex);  // Add lock
-        {
-            lock_guard queueLock(_queueMutex);
-            queue<vector<uint8_t>> empty;
-            _frameQueue.swap(empty);
-            _totalQueuedBytes = 0;
-        }        
+        scoped_lock lock(_mutex, _queueMutex);
+        queue<vector<uint8_t>> empty;
+        _frameQueue.swap(empty);
+        _totalQueuedBytes = 0;
     }
 
     void CloseSocket()
     {
-        lock_guard<mutex> lock(_mutex);  // Add lock    
+        lock_guard lock(_mutex);  // Add lock    
         if (_socketFd != -1)
         {
             close(_socketFd);


### PR DESCRIPTION
This:

- Modifies the way the TCP connections are configured during setup. It makes the way the difference between Apple and non-Apple (i.e., the name of one define) is handled in a more focused way, and in my opinion easier to read. Also, the send timeout config is now included in the overall "set socket options" function, so all the socket config logic is in one place. 
- Aligns how the ndscpp Makefile is structured more with that of the monitor. This also means running "make" for ndscpp is now the same as running "make all".
- Enables GitHub CI for the Apple platform