### PR TITLE
Polish up the json serialization a bit

### DIFF
--- a/canvas.h
+++ b/canvas.h
@@ -116,7 +116,8 @@ public:
 
 inline void to_json(nlohmann::json& j, const ICanvas & canvas) 
 {
-    j = {
+    j = 
+    {
         {"name", canvas.Name()},
         {"id", canvas.Id()},
         {"width", canvas.Graphics().Width()},
@@ -138,38 +139,10 @@ inline void from_json(const nlohmann::json& j, unique_ptr<ICanvas>& canvas)
         j.value("fps", 30u) 
     );
 
-    // Deserialize features if present
-    if (j.contains("features")) 
-    {
-        for (const auto& featureJson : j["features"])
-            canvas->AddFeature(featureJson.get<unique_ptr<ILEDFeature>>());
-    }
+    // Features()
+    for (const auto& featureJson : j.value("features", nlohmann::json::array()))
+        canvas->AddFeature(featureJson.get<unique_ptr<ILEDFeature>>());
 
-    // Deserialize the EffectsManager
-    if (j.contains("effectsManager"))
-    {
-        auto & effectsManager = canvas->Effects();  // Get reference to existing manager
-        const auto & managerJson = j["effectsManager"];
-
-        // Set FPS if present
-        if (managerJson.contains("fps")) 
-            effectsManager.SetFPS(managerJson["fps"].get<uint32_t>());    
-
-        // Load effects
-        if (managerJson.contains("effects")) 
-        {
-            for (const auto& effectJson : managerJson["effects"]) 
-            {
-                unique_ptr<ILEDEffect> effect;
-                from_json(effectJson, effect);
-                if (effect) 
-                    effectsManager.AddEffect(std::move(effect));
-                
-            }
-        }
-
-        // Set current effect index
-        if (managerJson.contains("currentEffectIndex")) 
-            effectsManager.SetCurrentEffectIndex(managerJson["currentEffectIndex"].get<size_t>());
-    }
+    // Effects()
+    from_json(j.at("effectsManager"), canvas->Effects());
 }

--- a/effects/paletteeffect.h
+++ b/effects/paletteeffect.h
@@ -4,6 +4,10 @@
 // 
 // A versatile effect that scrolls a palette of colors across the canvas.  The effect can be configured
 // with a variety of parameters to control the speed, density, and appearance of the scrolling colors.
+//
+// The palette effect advanced one pixel at a time and one color at a time through the supplied palette.
+// The speed of the color change and the speed of the pixel movement can be controlled independently.
+// If left at a density of 1, you get one color per pixel.  At 0.5, you get a new color every two pixels, etc.
 
 using namespace std;
 using namespace std::chrono;
@@ -112,7 +116,6 @@ inline void to_json(nlohmann::json& j, const PaletteEffect & effect)
 {
     j = {
             {"type",              PaletteEffect::EffectTypeName()},
-
             {"name",              effect.Name()},
             {"palette",           effect._Palette},
             {"ledColorPerSecond", effect._LEDColorPerSecond},

--- a/monitor/monitor.h
+++ b/monitor/monitor.h
@@ -109,12 +109,10 @@ inline std::string formatBytes(double bytes)
 inline std::string formatWifiSignal(double signal)
 {
     std::ostringstream oss;
-    if (signal == 1000)
-        oss << "1Gb/s";
-    else if (signal == 10000)
-        oss << "10Gb/s";
+    if (signal >= 100)
+        oss << " LAN";
     else
-        oss << std::abs((int)signal) << "dBm"; // Added abs() and removed decimal places
+        oss << ((int)signal) << "dBm"; // Added abs() and removed decimal places
     return oss.str();
 }
 
@@ -122,7 +120,10 @@ inline std::string formatTimeDelta(double delta)
 {
     std::string meter = buildMeter(delta, 3.0, 5);
     std::ostringstream oss;
-    oss << std::fixed << std::setprecision(1) << delta << "s " << meter;
+    if (abs(delta) > 100)
+        oss << "Unset";
+    else
+        oss << std::fixed << std::setprecision(1) << delta << "s " << meter;    
     return oss.str();
 }
 

--- a/palette.h
+++ b/palette.h
@@ -9,6 +9,14 @@ using namespace std;
 #include "json.hpp"
 #include "pixeltypes.h"
 
+// A pallete is a set of colors that can be queried with a floating point indexer to
+// get blends throughout the palette's range.  The palette can be set to blend or not
+// blend between colors.
+//
+// The palette can be queried with a floating point index, and will return a color
+// of that index and fraction from the set of original colors.  It wraps, so you can 
+// as for index 11.4 on an 8 color palette and it will return the color at index 3.4
+
 class Palette
 {
 protected:


### PR DESCRIPTION
Makes the dynamic serialization code ortogonal to the sexy deserialization code, so it's equally sexy now.

Improves the Canvas serialization by rellying on the EffectManager's serialization to do its thing.

Updates EffectManager's serialization to do its thing.

Adds a few comments in the palette code for future scholars to ponder over.
