### PR TITLE
Refactor effect (de)serializer maps into one

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -74,6 +74,8 @@ int main(int argc, char *argv[])
         }
     }
 
+    RegisterEffectSerializers();
+
     // Load the canvases from the configuration file or use hard-coded table defaults
     // depending on USE_DEMO_DATA being defined or not.
 


### PR DESCRIPTION
This doesn't fix anything that's broken, but it combines the two (de)serialization function tables into one, and makes the initialization of that one explicit. 

This limits the number of locations that need to be updated when an effect is added (or removed) to one, and makes it more visible that this is indeed necessary.

Note that this PR aims to update the Monday branch, not main.