### PR TITLE
API endpoint reader/writer locking

### DIFF
--- a/canvas.h
+++ b/canvas.h
@@ -21,7 +21,7 @@ class Canvas : public ICanvas
     EffectsManager          _effects;
     string                  _name;
     vector<shared_ptr<ILEDFeature>> _features;
-    mutable std::mutex     _featuresMutex;
+    mutable mutex           _featuresMutex;
 
 public:
     Canvas(string name, uint32_t width, uint32_t height, uint16_t fps = 30) : 
@@ -70,19 +70,19 @@ public:
 
     vector<shared_ptr<ILEDFeature>>  Features() override
     {
-        std::lock_guard<std::mutex> lock(_featuresMutex);
+        lock_guard lock(_featuresMutex);
         return _features;
     }
 
     const vector<shared_ptr<ILEDFeature>> Features() const override
     {
-        std::lock_guard<std::mutex> lock(_featuresMutex);
+        lock_guard lock(_featuresMutex);
         return _features;
     }
 
     uint32_t AddFeature(shared_ptr<ILEDFeature> feature) override
     {
-        std::lock_guard<std::mutex> lock(_featuresMutex);
+        lock_guard lock(_featuresMutex);
         if (!feature)
             throw invalid_argument("Cannot add a null feature.");
 
@@ -94,7 +94,7 @@ public:
 
     bool RemoveFeatureById(uint16_t featureId) override
     {
-        std::lock_guard<std::mutex> lock(_featuresMutex);
+        lock_guard lock(_featuresMutex);
         for (size_t i = 0; i < _features.size(); ++i)
         {
             if (_features[i]->Id() == featureId)

--- a/controller.h
+++ b/controller.h
@@ -31,7 +31,7 @@ class Controller : public IController
 
     vector<shared_ptr<ICanvas>> _canvases;
     uint16_t                    _port;
-    mutable std::mutex          _canvasMutex;
+    mutable mutex               _canvasMutex;
 
   public:
 
@@ -45,7 +45,7 @@ class Controller : public IController
 
     vector<shared_ptr<ICanvas>> Canvases() const override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         return _canvases;
     }
 
@@ -79,7 +79,7 @@ class Controller : public IController
 
     bool AddFeatureToCanvas(uint16_t canvasId, shared_ptr<ILEDFeature> feature) override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Adding feature to canvas {}...", canvasId);
         GetCanvasById(canvasId)->AddFeature(feature);
         return true;
@@ -87,7 +87,7 @@ class Controller : public IController
 
     void RemoveFeatureFromCanvas(uint16_t canvasId, uint16_t featureId) override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Removing feature {} from canvas {}...", featureId, canvasId);
         GetCanvasById(canvasId)->RemoveFeatureById(featureId);
     }
@@ -99,7 +99,7 @@ class Controller : public IController
 
     void LoadSampleCanvases()
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Loading sample canvases...");
 
         _canvases.clear();
@@ -356,7 +356,7 @@ class Controller : public IController
 
     void Connect() override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Connecting canvases...");
 
         for (const auto &canvas : _canvases)
@@ -366,7 +366,7 @@ class Controller : public IController
 
     void Disconnect() override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Disconnecting canvases...");
 
         for (const auto &canvas : _canvases)
@@ -376,7 +376,7 @@ class Controller : public IController
 
     void Start() override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Starting canvases...");
 
         for (auto &canvas : _canvases)
@@ -385,7 +385,7 @@ class Controller : public IController
 
     void Stop() override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         logger->debug("Stopping canvases...");
 
         for (auto &canvas : _canvases)
@@ -399,7 +399,7 @@ class Controller : public IController
         // This is a bit odd; we try get the current canvas with the ID specified by the new one,
         // and we only proceed in the exception case if the canvas doesn't exist, where we add it
 
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         try
         {
             GetCanvasById(ptrCanvas->Id());
@@ -426,7 +426,7 @@ class Controller : public IController
             for (auto &feature : canvas->Features())
                 feature->Socket().Stop();
             
-            std::lock_guard<std::mutex> lock(_canvasMutex);
+            lock_guard lock(_canvasMutex);
             // Erase the canvas from _canvases
             _canvases.erase(
                 remove_if(_canvases.begin(), _canvases.end(), [id](const auto &canvas) { return canvas->Id() == id; }),
@@ -445,7 +445,7 @@ class Controller : public IController
     {
         logger->debug("Updating canvas {}...", ptrCanvas->Name());
 
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         try 
         {
             // Find index of canvas we want to update
@@ -479,7 +479,7 @@ class Controller : public IController
 
     vector<reference_wrapper<ISocketChannel>> GetSockets() const override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         vector<reference_wrapper<ISocketChannel>> sockets;
         for (const auto &canvas : _canvases)
             for (const auto &feature : canvas->Features())
@@ -489,7 +489,7 @@ class Controller : public IController
 
     const ISocketChannel & GetSocketById(uint16_t id) const override
     {
-        std::lock_guard<std::mutex> lock(_canvasMutex);
+        lock_guard lock(_canvasMutex);
         for (const auto &canvas : _canvases)
             for (const auto &feature : canvas->Features())
                 if (feature->Id() == id)

--- a/effectsmanager.h
+++ b/effectsmanager.h
@@ -22,12 +22,12 @@ using namespace std::chrono;
 
 class EffectsManager : public IEffectsManager
 {
-    uint16_t _fps;
-    int _currentEffectIndex; // Index of the current effect
-    atomic<bool> _running;
-    mutable std::mutex _effectsMutex;  // Add mutex as member
+    uint16_t      _fps;
+    int           _currentEffectIndex; // Index of the current effect
+    atomic<bool>  _running;
+    mutable mutex _effectsMutex;  // Add mutex as member
     vector<shared_ptr<ILEDEffect>> _effects;
-    thread _workerThread;
+    thread        _workerThread;
 
 public:
     EffectsManager(uint16_t fps = 30) : _fps(fps), _currentEffectIndex(-1), _running(false) // No effect selected initially
@@ -61,14 +61,14 @@ public:
 
     vector<shared_ptr<ILEDEffect>> Effects() const override
     {
-        std::lock_guard<std::mutex> lock(_effectsMutex);
+        lock_guard lock(_effectsMutex);
         return _effects;
     }
 
     // Add an effect to the manager
     void AddEffect(shared_ptr<ILEDEffect> effect) override
     {
-        std::lock_guard<std::mutex> lock(_effectsMutex);
+        lock_guard lock(_effectsMutex);
 
         if (!effect)
             throw invalid_argument("Cannot add a null effect.");
@@ -82,7 +82,7 @@ public:
     // Remove an effect from the manager
     void RemoveEffect(shared_ptr<ILEDEffect> &effect) override
     {
-        std::lock_guard<std::mutex> lock(_effectsMutex);
+        lock_guard lock(_effectsMutex);
 
         if (!effect)
             throw invalid_argument("Cannot remove a null effect.");
@@ -153,7 +153,7 @@ public:
 
     void ClearEffects() override
     {
-        std::lock_guard<std::mutex> lock(_effectsMutex);
+        lock_guard lock(_effectsMutex);
         _effects.clear();
         _currentEffectIndex = -1;
     }
@@ -222,7 +222,7 @@ public:
 
     void SetEffects(vector<shared_ptr<ILEDEffect>> effects) override
     {
-        std::lock_guard<std::mutex> lock(_effectsMutex);
+        lock_guard lock(_effectsMutex);
         _effects = std::move(effects);
     }
 

--- a/webserver.h
+++ b/webserver.h
@@ -12,7 +12,7 @@ using namespace std;
 
 class WebServer
 {
-    mutable shared_mutex _mutex;
+    mutable shared_mutex _apiMutex;
 
     struct HeaderMiddleware
     {
@@ -53,7 +53,7 @@ public:
             {
                 try
                 {
-                    shared_lock readLock(_mutex);
+                    shared_lock readLock(_apiMutex);
                     return nlohmann::json{{"controller", _controller}}.dump();
                 }
                 catch(const std::exception& e)
@@ -70,7 +70,7 @@ public:
             {
                 try
                 {
-                    shared_lock readLock(_mutex);
+                    shared_lock readLock(_apiMutex);
                     return nlohmann::json{{"sockets", _controller.GetSockets()}}.dump();
                 }
                 catch(const std::exception& e)
@@ -88,7 +88,7 @@ public:
             {
                 try
                 {
-                    shared_lock readLock(_mutex);
+                    shared_lock readLock(_apiMutex);
                     return nlohmann::json{{"socket", _controller.GetSocketById(socketId)}}.dump();
                 }
                 catch(const std::exception& e)
@@ -105,7 +105,7 @@ public:
             {
                 try
                 {
-                    shared_lock readLock(_mutex);
+                    shared_lock readLock(_apiMutex);
                     return nlohmann::json(_controller.Canvases()).dump();
                 }
                 catch(const std::exception& e)
@@ -122,7 +122,7 @@ public:
             {
                 try
                 {
-                    shared_lock readLock(_mutex);
+                    shared_lock readLock(_apiMutex);
                     auto allCanvases = _controller.Canvases();
                     if (id < 0 || id >= allCanvases.size())
                         return {crow::NOT_FOUND, R"({"error": "Canvas not found"})"};
@@ -146,7 +146,7 @@ public:
                         // Parse and deserialize JSON payload
                         auto jsonPayload = nlohmann::json::parse(req.body);
 
-                        unique_lock writeLock(_mutex);
+                        unique_lock writeLock(_apiMutex);
                         uint32_t newID = _controller.AddCanvas(jsonPayload.get<shared_ptr<ICanvas>>());
                         writeLock.unlock();
 
@@ -171,7 +171,7 @@ public:
                         auto reqJson = nlohmann::json::parse(req.body);
                         auto feature = reqJson.get<shared_ptr<ILEDFeature>>();
 
-                        unique_lock writeLock(_mutex);
+                        unique_lock writeLock(_apiMutex);
                         auto newId = _controller.GetCanvasById(canvasId)->AddFeature(feature);
                         writeLock.unlock();
 
@@ -191,7 +191,7 @@ public:
                 {
                     try
                     {
-                        unique_lock writeLock(_mutex);
+                        unique_lock writeLock(_apiMutex);
                         auto canvas = _controller.GetCanvasById(canvasId);
                         canvas->RemoveFeatureById(featureId);
                         writeLock.unlock();
@@ -212,7 +212,7 @@ public:
                 {
                     try
                     {
-                        unique_lock writeLock(_mutex);
+                        unique_lock writeLock(_apiMutex);
                         _controller.DeleteCanvasById(id);
                         writeLock.unlock();
 

--- a/webserver.h
+++ b/webserver.h
@@ -148,7 +148,7 @@ public:
 
                         unique_lock writeLock(_mutex);
                         uint32_t newID = _controller.AddCanvas(jsonPayload.get<shared_ptr<ICanvas>>());
-                        writeLock.release();
+                        writeLock.unlock();
 
                         if (newID == -1)
                             return {crow::BAD_REQUEST, "Error, likely canvas with that ID already exists."};
@@ -173,7 +173,7 @@ public:
 
                         unique_lock writeLock(_mutex);
                         auto newId = _controller.GetCanvasById(canvasId)->AddFeature(feature);
-                        writeLock.release();
+                        writeLock.unlock();
 
                         return nlohmann::json{{"id", newId}}.dump();
                     } 
@@ -194,7 +194,7 @@ public:
                         unique_lock writeLock(_mutex);
                         auto canvas = _controller.GetCanvasById(canvasId);
                         canvas->RemoveFeatureById(featureId);
-                        writeLock.release();
+                        writeLock.unlock();
                         
                         return crow::response(crow::OK);
                     }
@@ -212,9 +212,9 @@ public:
                 {
                     try
                     {
-                        unique_lock lock(_mutex);
+                        unique_lock writeLock(_mutex);
                         _controller.DeleteCanvasById(id);
-                        lock.release();
+                        writeLock.unlock();
 
                         return crow::response(crow::OK);
                     }


### PR DESCRIPTION
This adds a reader/writer lock mechanism to the REST API endpoints, in an attempt to prevent parallelization issues. It also includes some small consistency changes at the code level.

Note that:

- I've been generous with the range of reader locks (shared_lock) on GET endpoints, to ensure the inclusion of the JSON serialization that is most of the work.
- I've aimed to make the writer locks (unique_lock) cover the least amount of code possible, explicitly _excluding_ any JSON processing around the actual modification operations on the core objects. I've done this is to minimize the impact on overall API performance.
- **I haven't tested this.** With my single-canvas, single-effect, single-feature setup, it just lacks the complexity required to make any test representative. I know it compiles. :)
- This PR aims to update the `Tests` branch, not `main`.
