### PR TITLE
Remove references to canvas.fps

### DIFF
--- a/monitor/content.cpp
+++ b/monitor/content.cpp
@@ -14,7 +14,7 @@ using json = nlohmann::json;
 const std::vector<std::pair<std::string, int>> COLUMNS =
     {
         {"Canvas", 10},   // Canvas name (matched to Feature width)
-        {"Feature", 10},  // Feature name 
+        {"Feature", 10},  // Feature name
         {"Host", 14},     // Hostname
         {"Size", 7},      // Dimensions
         {"Cx", 3},        // Reconnects
@@ -43,7 +43,7 @@ void Monitor::drawContent()
         for (const auto &canvasJson : j)
         {
             std::string canvasName = canvasJson["name"].get<std::string>();
-            int canvasFps = canvasJson["fps"].get<int>();
+            int canvasFps = canvasJson["effectsManager"]["fps"].get<int>();
             std::string currentEffect = canvasJson.contains("currentEffectName")
                                           ? canvasJson.at("currentEffectName").get<std::string>()
                                           : "---";
@@ -106,14 +106,14 @@ void Monitor::drawContent()
                     {
                         const auto &stats = featureJson["lastClientResponse"];
                         int featureFps = stats["fpsDrawing"].get<int>();
-                        
+
                         int colorPair = (featureFps < 0.8 * canvasFps) ? 6 : 1;
                         wattron(contentWin, COLOR_PAIR(colorPair));
                         mvwprintw(contentWin, row - scrollOffset, x, "%d", featureFps);
                         wattroff(contentWin, COLOR_PAIR(colorPair));
-                        
+
                         mvwprintw(contentWin, row - scrollOffset, x + std::to_string(featureFps).length(), "/%d", canvasFps);
-                        
+
                         int totalWidth = std::to_string(featureFps).length() + 1 + std::to_string(canvasFps).length();
                         mvwprintw(contentWin, row - scrollOffset, x + totalWidth, "%*s", COLUMNS[5].second - totalWidth, "");
                     }
@@ -130,7 +130,7 @@ void Monitor::drawContent()
                         try
                         {
                             size_t queueDepth = featureJson["queueDepth"].get<size_t>();
-                            int queueColor = queueDepth < 100 ? 1 : 
+                            int queueColor = queueDepth < 100 ? 1 :
                                            queueDepth < 250 ? 6 : 2;
 
                             std::wstring bar = buildProgressBar(queueDepth, kFatQueue, 6);

--- a/ndsweb/src/app/components/monitor/monitor.component.ts
+++ b/ndsweb/src/app/components/monitor/monitor.component.ts
@@ -396,7 +396,7 @@ export class MonitorComponent implements OnChanges {
                 : reconnectCount < 10
                 ? 'warning'
                 : 'danger',
-            canvasFps: canvas.fps,
+            canvasFps: canvas.effectsManager.fps,
             featureFps: 90,
             fpsStatus: null,
             bufferSize: null,
@@ -444,7 +444,7 @@ export class MonitorComponent implements OnChanges {
                     ? 'warning'
                     : 'danger';
 
-            data.fpsStatus = fps < 0.8 * canvas.fps ? 'warning' : 'good';
+            data.fpsStatus = fps < 0.8 * canvas.effectsManager.fps ? 'warning' : 'good';
             data.bufferStatus =
                 ratio >= 0.25 && ratio <= 0.85
                     ? 'good'

--- a/ndsweb/src/app/services/monitor.service.ts
+++ b/ndsweb/src/app/services/monitor.service.ts
@@ -43,7 +43,6 @@ export interface Canvas {
         type: string;
     };
     features: Feature[];
-    fps: number;
     height: number;
     id: number;
     name: string;

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -163,7 +163,7 @@ TEST_F(APITest, CanvasFeatureOperations)
         {"height", 100}};
 
     // Send the POST request and capture the response
-    auto createCanvasResponse = cpr::Post(cpr::Url{BASE_URL + "/canvases"}, 
+    auto createCanvasResponse = cpr::Post(cpr::Url{BASE_URL + "/canvases"},
                                           cpr::Body{canvasData.dump()},
                                           jsonHeader, noPersistParam);
 
@@ -213,7 +213,7 @@ TEST_F(APITest, CanvasFeatureOperations)
                                             noPersistParam);
 }
 
-/* Causes a lot of logging of errors in the server 
+/* Causes a lot of logging of errors in the server
 // Test error cases
 TEST_F(APITest, ErrorHandling)
 {
@@ -249,10 +249,10 @@ TEST_F(APITest, MultipleCanvasOperations)
                 {"width", 100},
                 {"height", 100}
             };
-            
-            return cpr::Post(cpr::Url{BASE_URL + "/canvases"}, 
+
+            return cpr::Post(cpr::Url{BASE_URL + "/canvases"},
                              cpr::Body{canvasData.dump()},
-                             jsonHeader, noPersistParam); 
+                             jsonHeader, noPersistParam);
         }));
     }
 
@@ -277,9 +277,9 @@ TEST_F(APITest, MultipleCanvasOperations)
     for (int id : canvasIds)
     {
         deleteFutures.push_back(std::async(std::launch::async, [id]()
-        { 
+        {
             return cpr::Delete(cpr::Url{BASE_URL + "/canvases/" + std::to_string(id)},
-                                noPersistParam); 
+                                noPersistParam);
         }));
     }
 
@@ -302,7 +302,7 @@ TEST_F(APITest, MultipleFeatureOperations)
         {"width", 1000},
         {"height", 1000}};
 
-    auto createCanvasResponse = cpr::Post(cpr::Url{BASE_URL + "/canvases"}, 
+    auto createCanvasResponse = cpr::Post(cpr::Url{BASE_URL + "/canvases"},
                                           cpr::Body{canvasData.dump()},
                                           jsonHeader, noPersistParam);
 
@@ -334,10 +334,10 @@ TEST_F(APITest, MultipleFeatureOperations)
                 {"redGreenSwap", false},
                 {"clientBufferCount", 8}
             };
-            
+
             return cpr::Post(cpr::Url{BASE_URL + "/canvases/" + std::to_string(canvasId) + "/features"},
                              cpr::Body{featureData.dump()},
-                             jsonHeader, noPersistParam); 
+                             jsonHeader, noPersistParam);
         }));
     }
 
@@ -391,14 +391,14 @@ TEST_F(APITest, RapidCreationDeletion)
 
             json canvasData = {
                 {"id", -1},
-                { "name", "Cycle " + std::to_string(cycle) + " Canvas " + std::to_string(i) + " " + std::to_string(std::time(nullptr)) },   
+                { "name", "Cycle " + std::to_string(cycle) + " Canvas " + std::to_string(i) + " " + std::to_string(std::time(nullptr)) },
                 {"width", 100},
                 {"height", 100}};
 
             auto response = cpr::Post(cpr::Url{BASE_URL + "/canvases"},
                                       cpr::Body{canvasData.dump()},
                                       jsonHeader, noPersistParam);
-                
+
             ASSERT_EQ(response.status_code, 201);
             auto jsonResponse = json::parse(response.text);
             cycleCanvasIds.push_back(jsonResponse["id"].get<int>());
@@ -527,10 +527,12 @@ TEST_F(APITest, CanvasFeatureEffectWithSchedule)
     );
     ASSERT_EQ(getCanvasResponse.status_code, 200);
     auto canvasWithEffects = json::parse(getCanvasResponse.text);
-    
+
     // Verify effects through effectsManager
     ASSERT_TRUE(canvasWithEffects.contains("effectsManager"));
     const auto& effectsManager = canvasWithEffects["effectsManager"];
+    ASSERT_TRUE(effectsManager.contains("fps"));
+    ASSERT_EQ(effectsManager["fps"].get<int>(), 30); // Default FPS
     ASSERT_TRUE(effectsManager.contains("effects"));
     const auto& effects = effectsManager["effects"];
     ASSERT_EQ(effects.size(), (size_t) 2);

--- a/tests/tests.cpp
+++ b/tests/tests.cpp
@@ -202,6 +202,30 @@ TEST_F(APITest, CanvasFeatureOperations)
     auto featureInfo = json::parse(createFeatureResponse.text);
     int featureId = featureInfo["id"].get<int>();
 
+    auto getCanvasResponse = cpr::Get(cpr::Url{BASE_URL + "/canvases/" + std::to_string(newCanvasId)}, noPersistParam);
+
+    ASSERT_EQ(getCanvasResponse.status_code, 200);
+    auto canvasJson = json::parse(getCanvasResponse.text);
+    ASSERT_TRUE(canvasJson.contains("features"));
+    ASSERT_FALSE(canvasJson["features"].empty());
+
+    auto features = canvasJson["features"];
+    bool featureFound = false;
+
+    for (const auto &feature : features)
+    {
+        if (feature["id"].get<int>() == featureId)
+        {
+            featureFound = true;
+            ASSERT_TRUE(feature.contains("isConnected"));
+            ASSERT_EQ(feature["friendlyName"], "Test Feature");
+            ASSERT_EQ(feature["width"], 32);
+            ASSERT_EQ(feature["height"], 16);
+        }
+    }
+
+    ASSERT_TRUE(featureFound); // Ensure the feature was added to the canvas
+
     // Delete feature
     auto deleteFeatureResponse = cpr::Delete(
         cpr::Url{BASE_URL + "/canvases/" + std::to_string(newCanvasId) + "/features/" + std::to_string(featureId)},

--- a/webserver.h
+++ b/webserver.h
@@ -5,13 +5,6 @@
 #include <ranges>
 #include <shared_mutex>
 #include "json.hpp"
-
-#define ASIO_NO_DEPRECATED 1
-
-namespace asio {
-    typedef io_context io_service;
-} // namespace asio
-
 #include "crow_all.h"
 #include "controller.h"
 

--- a/webserver.h
+++ b/webserver.h
@@ -5,6 +5,13 @@
 #include <ranges>
 #include <shared_mutex>
 #include "json.hpp"
+
+#define ASIO_NO_DEPRECATED 1
+
+namespace asio {
+    typedef io_context io_service;
+} // namespace asio
+
 #include "crow_all.h"
 #include "controller.h"
 
@@ -53,7 +60,7 @@ class WebServer
             reqJson = nlohmann::json::parse(req.body);
 
         unique_lock writeLock(_apiMutex);
-        
+
         if (reqJson.contains("canvasIds"))
         {
             for (auto& canvasId : reqJson["canvasIds"])
@@ -116,7 +123,7 @@ public:
 
         // Detail a single socket
 
-        CROW_ROUTE(_crowApp, "/api/sockets/<int>") 
+        CROW_ROUTE(_crowApp, "/api/sockets/<int>")
             .methods(crow::HTTPMethod::GET)([&](int socketId) -> crow::response
             {
                 try
@@ -156,16 +163,16 @@ public:
                 try
                 {
                     shared_lock readLock(_apiMutex);
-                    return nlohmann::json(*_controller.GetCanvasById(id)).dump(); 
+                    return nlohmann::json(*_controller.GetCanvasById(id)).dump();
                 }
                 catch(const exception& e)
                 {
                     logger->error("Error in /api/canvases/{}: {}", id, e.what());
                     return {crow::BAD_REQUEST, string("Error: ") + e.what()};
                 }
-                
+
             });
-            
+
         CROW_ROUTE(_crowApp, "/api/canvases/start")
             .methods(crow::HTTPMethod::POST)([&](const crow::request& req) -> crow::response
             {
@@ -200,7 +207,7 @@ public:
         CROW_ROUTE(_crowApp, "/api/canvases")
             .methods(crow::HTTPMethod::POST)([&](const crow::request& req) -> crow::response
             {
-                try 
+                try
                 {
                     // Parse and deserialize JSON payload
                     auto reqJson = nlohmann::json::parse(req.body);
@@ -220,9 +227,9 @@ public:
                     if (effectsManager.WantsToRun() && effectsManager.EffectCount() > 0)
                         effectsManager.Start(*canvas);
 
-                    return crow::response(201, nlohmann::json{{"id", newID}}.dump());                    
-                } 
-                catch (const exception& e) 
+                    return crow::response(201, nlohmann::json{{"id", newID}}.dump());
+                }
+                catch (const exception& e)
                 {
                     logger->error("Error in /api/canvases POST: {}", e.what());
                     return {crow::BAD_REQUEST, string("Error: ") + e.what()};
@@ -233,7 +240,7 @@ public:
             CROW_ROUTE(_crowApp, "/api/canvases/<int>/features")
                 .methods(crow::HTTPMethod::POST)([&](const crow::request& req, int canvasId) -> crow::response
                 {
-                    try 
+                    try
                     {
                         auto reqJson = nlohmann::json::parse(req.body);
                         auto feature = reqJson.get<shared_ptr<ILEDFeature>>();
@@ -245,8 +252,8 @@ public:
 
                         return nlohmann::json{{"id", newId}}.dump();
 
-                    } 
-                    catch (const exception& e) 
+                    }
+                    catch (const exception& e)
                     {
                         logger->error("Error in /api/canvases/{}/features POST: {}", canvasId, e.what());
                         return {crow::BAD_REQUEST, string("Error: ") + e.what()};
@@ -265,7 +272,7 @@ public:
                         canvas->RemoveFeatureById(featureId);
                         PersistController(req);
                         writeLock.unlock();
-                        
+
                         return crow::response(crow::OK);
                     }
                     catch(const exception& e)
@@ -274,7 +281,7 @@ public:
                         return crow::response(crow::BAD_REQUEST, string("Error: ") + e.what());
                     }
                 });
-                
+
 
             // Delete canvas
             CROW_ROUTE(_crowApp, "/api/canvases/<int>")
@@ -300,26 +307,26 @@ public:
         CROW_ROUTE(_crowApp, "/api/canvases/<int>/effects")
             .methods(crow::HTTPMethod::POST)([&](const crow::request& req, int canvasId) -> crow::response
             {
-                try 
+                try
                 {
                     auto reqJson = nlohmann::json::parse(req.body);
                     auto effect = reqJson.get<shared_ptr<ILEDEffect>>();
 
                     unique_lock writeLock(_apiMutex);
                     auto canvas = _controller.GetCanvasById(canvasId);
-                    
+
                     // Get current effects
                     auto& effectsManager = canvas->Effects();
-                    
+
                     // Add the new effect
                     effectsManager.AddEffect(effect);
-                    
+
                     PersistController(req);
                     writeLock.unlock();
 
                     return crow::response(crow::OK);
-                } 
-                catch (const exception& e) 
+                }
+                catch (const exception& e)
                 {
                     logger->error("Error adding effect to canvas {}: {}", canvasId, e.what());
                     return crow::response(crow::BAD_REQUEST, string("Error: ") + e.what());


### PR DESCRIPTION
This removes references to the canvas.fps element in the API's responses, which was a duplicate of canvas.effectsManager.fps and was removed in #34.

Concretely:
- ledmon and webmon were updated to pull the fps from the one place it now exists.
- The canvas CRUD test in the test suite was updated to check for the fps presence, and its default value.
- The feature operations test in the test suite was updated to retrieve the created feature and verify that it contains the elements ledmon assumes to be present.

Furthermore, this PR fixes the failing builds on MacOS by bumping Crow to the current version, which moved away from using Asio features that were previously deprecated and have now become unavailable in  the most recent Asio versions.

Current state of what works:
- ndscpp and ledmon build and run
- the test suite builds and all tests pass
- CI completes successfully on Linux (Ubuntu) and MacOS