### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: CI
 
 on: [push, pull_request, workflow_dispatch]

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,7 @@
+name: CI
+
 permissions:
   contents: read
-name: CI
 
 on: [push, pull_request, workflow_dispatch]
 


### PR DESCRIPTION
Potential fix for [https://github.com/PlummersSoftwareLLC/NDSCPP/security/code-scanning/1](https://github.com/PlummersSoftwareLLC/NDSCPP/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file to restrict the permissions of the GITHUB_TOKEN used by Actions. Since the workflow only checks out code and performs local builds/tests, the minimal necessary permission is `contents: read`. This can be set either at the top level (applies to all jobs) or at the job level. The best fix is to place the following block immediately below the workflow name or event trigger lines, ensuring the restriction applies to all jobs unless overridden. Only the `.github/workflows/CI.yml` file needs to change, and no additional imports or dependencies are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
